### PR TITLE
Fix indentation in cloud-init config

### DIFF
--- a/scripts/01_openstack.sh
+++ b/scripts/01_openstack.sh
@@ -10,4 +10,4 @@ rc-update add cloud-config default
 rc-update add cloud-final default
 
 echo "PasswordAuthentication no" >> /etc/ssh/sshd_config
-sed -i '/lock_passwd/c\     lock_passwd: False' /etc/cloud/cloud.cfg
+sed -i '/lock_passwd/c\    lock_passwd: False' /etc/cloud/cloud.cfg


### PR DESCRIPTION
The indentation in the cloud-init config changed which results in a invalid config. 🤷🏻‍♂️ 