### PR TITLE
bump alpine to version 3.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Install Packer: https://www.packer.io/intro/getting-started/install.html
 
 ```
 packer build -var "root_pw=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 32)" alpine.json
-qemu-img convert -f vmdk -O raw output-virtualbox-iso/alpine320-disk001.vmdk output-virtualbox-iso/alpine320-disk001.raw
-openstack image create --file output-virtualbox-iso/alpine320-disk001.raw --disk-format raw --property os_distro='alpine' --property os_type='linux' --property hw_vif_multiqueue_enabled='True' --container-format bare alpine
+qemu-img convert -f vmdk -O raw output-virtualbox-iso/alpine323-disk001.vmdk output-virtualbox-iso/alpine323-disk001.raw
+openstack image create --file output-virtualbox-iso/alpine323-disk001.raw --disk-format raw --property os_distro='alpine' --property os_type='linux' --property hw_vif_multiqueue_enabled='True' --container-format bare --public yawol-alpine-base
 ```

--- a/alpine.json
+++ b/alpine.json
@@ -20,8 +20,8 @@
       "guest_additions_mode": "disable",
       "guest_os_type": "Linux_64",
       "http_directory": "http",
-      "iso_checksum": "file:https://dl-cdn.alpinelinux.org/alpine/v3.20/releases/x86_64/alpine-virt-3.20.2-x86_64.iso.sha256",
-      "iso_url": "https://dl-cdn.alpinelinux.org/alpine/v3.20/releases/x86_64/alpine-virt-3.20.2-x86_64.iso",
+      "iso_checksum": "file:https://dl-cdn.alpinelinux.org/alpine/v3.23/releases/x86_64/alpine-virt-3.23.3-x86_64.iso.sha256",
+      "iso_url": "https://dl-cdn.alpinelinux.org/alpine/v3.23/releases/x86_64/alpine-virt-3.23.3-x86_64.iso",
       "shutdown_command": "/sbin/poweroff",
       "ssh_password": "{{user `root_pw`}}",
       "ssh_username": "root",
@@ -40,7 +40,7 @@
           "{{user `cpus`}}"
         ]
       ],
-      "vm_name": "alpine320"
+      "vm_name": "alpine323"
     }
   ],
   "provisioners": [

--- a/scripts/01_openstack.sh
+++ b/scripts/01_openstack.sh
@@ -4,10 +4,8 @@ apk add --no-cache cloud-init
 apk add --no-cache acpi
 
 # Start Cloud-Init on Boot
-rc-update add cloud-init default
-rc-update add cloud-init-local default
-rc-update add cloud-config default
-rc-update add cloud-final default
+setup-cloud-init
+rc-update -u
 
 echo "PasswordAuthentication no" >> /etc/ssh/sshd_config
 sed -i '/lock_passwd/c\    lock_passwd: False' /etc/cloud/cloud.cfg

--- a/scripts/02_docker.sh
+++ b/scripts/02_docker.sh
@@ -1,4 +1,0 @@
-set -ux
-
-apk add docker
-rc-update add docker default


### PR DESCRIPTION
bump alpine to version 3.23


There was a change needed in the enablement of the cloud-init services otherwise the cloud-init did not start at server start.